### PR TITLE
feat: Add Ollama FastAPI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# ollama-wrapper-jules
-Test repository for Jules
+# Ollama FastAPI Wrapper
+
+This project provides a simple FastAPI wrapper for interacting with the Ollama API.
+
+## Setup
+
+1.  **Install Ollama:**
+    Make sure you have Ollama installed and running. Refer to the [official Ollama documentation](https://ollama.com/download) for installation instructions.
+
+2.  **Create a virtual environment (recommended):**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+    ```
+
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Running the Application
+
+To run the FastAPI application, use uvicorn:
+
+```bash
+uvicorn main:app --reload
+```
+
+The application will typically be available at `http://127.0.0.1:8000`.
+
+## Usage
+
+You can send requests to the `/generate` endpoint to interact with an Ollama model.
+
+**Request Body:**
+
+*   `model` (string): The name of the Ollama model to use (e.g., "llama3").
+*   `prompt` (string): The prompt to send to the model.
+
+**Example using `curl`:**
+
+```bash
+curl -X POST "http://127.0.0.1:8000/generate" -H "Content-Type: application/json" -d '{
+  "model": "llama3",
+  "prompt": "Why is the sky blue?"
+}'
+```
+
+**Example using Python `requests`:**
+
+```python
+import requests
+import json
+
+url = "http://127.0.0.1:8000/generate"
+payload = {
+    "model": "llama3", # Or any other model you have pulled with ollama
+    "prompt": "Tell me a joke about programming."
+}
+headers = {
+    "Content-Type": "application/json"
+}
+
+response = requests.post(url, data=json.dumps(payload), headers=headers)
+
+if response.status_code == 200:
+    print("Success:")
+    print(response.json())
+else:
+    print(f"Error: {response.status_code}")
+    print(response.text)
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from ollama import Client
+
+# Create a FastAPI app instance
+app = FastAPI()
+
+# Define a Pydantic model for the request body
+class GenerateRequest(BaseModel):
+    model: str
+    prompt: str
+
+# Create a POST endpoint /generate
+@app.post("/generate")
+async def generate(request: GenerateRequest):
+    try:
+        # Initialize an ollama.Client instance
+        client = Client()
+
+        # Call client.chat()
+        response = client.chat(
+            model=request.model,
+            messages=[
+                {
+                    'role': 'user',
+                    'content': request.prompt,
+                }
+            ]
+        )
+        # Return the response dictionary directly
+        return response
+    except Exception as e:
+        # Basic error handling
+        raise HTTPException(status_code=500, detail=f"Error interacting with Ollama API: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+ollama
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,60 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+# Adjust the import path if your main.py is in a subdirectory (e.g., app.main)
+from main import app 
+
+client = TestClient(app)
+
+@patch('ollama.Client')
+def test_generate_success(MockOllamaClient):
+    # Configure the mock
+    mock_ollama_instance = MockOllamaClient.return_value
+    mock_response = {
+        "model": "llama3",
+        "created_at": "2023-10-26T12:00:00Z",
+        "message": {
+            "role": "assistant",
+            "content": "The sky is blue due to Rayleigh scattering."
+        },
+        "done": True
+    }
+    mock_ollama_instance.chat.return_value = mock_response
+
+    # Make the request
+    response = client.post("/generate", json={"model": "llama3", "prompt": "Why is the sky blue?"})
+
+    # Assertions
+    assert response.status_code == 200
+    assert response.json() == mock_response
+    mock_ollama_instance.chat.assert_called_once_with(
+        model="llama3",
+        messages=[{'role': 'user', 'content': "Why is the sky blue?"}]
+    )
+
+@patch('ollama.Client')
+def test_generate_ollama_error(MockOllamaClient):
+    # Configure the mock to raise an exception
+    mock_ollama_instance = MockOllamaClient.return_value
+    mock_ollama_instance.chat.side_effect = Exception("Ollama connection error")
+
+    # Make the request
+    response = client.post("/generate", json={"model": "llama3", "prompt": "What happens on error?"})
+
+    # Assertions
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Error interacting with Ollama API: Ollama connection error"}
+    mock_ollama_instance.chat.assert_called_once_with(
+        model="llama3",
+        messages=[{'role': 'user', 'content': "What happens on error?"}]
+    )
+
+def test_generate_invalid_request_body():
+    # Missing 'prompt'
+    response = client.post("/generate", json={"model": "llama3"})
+    assert response.status_code == 422 # Unprocessable Entity for Pydantic validation errors
+
+    # Missing 'model'
+    response = client.post("/generate", json={"prompt": "test"})
+    assert response.status_code == 422


### PR DESCRIPTION
This commit introduces a FastAPI application that acts as a wrapper for the Ollama API.

Key features:
- A `/generate` POST endpoint that accepts a model name and a prompt.
- Uses the `ollama` Python client library to interact with a running Ollama instance via the `chat` method.
- Includes basic error handling for Ollama API interactions.
- Pydantic model for request body validation.
- `requirements.txt` updated with `fastapi`, `uvicorn[standard]`, `ollama`, and `pytest`.
- `README.md` updated with setup, run, and usage instructions.
- Basic unit tests for the `/generate` endpoint, including success cases, Ollama API error handling, and invalid request body scenarios. Tests use `fastapi.testclient` and mock the Ollama client.