### PR TITLE
feat: Add conversation mode to Ollama wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,30 @@ You can send requests to the `/generate` endpoint to interact with an Ollama mod
 
 **Request Body:**
 
-*   `model` (string): The name of the Ollama model to use (e.g., "llama3").
-*   `prompt` (string): The prompt to send to the model.
+*   `model` (string, required): The name of the Ollama model to use (e.g., "llama3").
+*   `prompt` (string, optional): The prompt to send to the model for a single-turn interaction.
+*   `messages` (list of objects, optional): A list of message objects for conversational context. Each object should have:
+    *   `role` (string): The role of the sender (e.g., "user", "assistant").
+    *   `content` (string): The content of the message.
 
-**Example using `curl`:**
+**Important:** Either 'prompt' or a non-empty 'messages' list must be provided.
+*   If `messages` is provided and is not empty, it will be used for conversational context, and `prompt` will be ignored.
+*   If `messages` is not provided or is empty, `prompt` must be provided and will be used to initiate a new conversation with a single user message.
 
+---
+
+**Examples for Single-Turn Interaction (using `prompt`):**
+
+**`curl`:**
 ```bash
 curl -X POST "http://127.0.0.1:8000/generate" -H "Content-Type: application/json" -d '{
   "model": "llama3",
   "prompt": "Why is the sky blue?"
 }'
 ```
+*This example uses the `prompt` field for a single-turn interaction.*
 
-**Example using Python `requests`:**
-
+**Python `requests`:**
 ```python
 import requests
 import json
@@ -56,6 +66,51 @@ url = "http://127.0.0.1:8000/generate"
 payload = {
     "model": "llama3", # Or any other model you have pulled with ollama
     "prompt": "Tell me a joke about programming."
+}
+headers = {
+    "Content-Type": "application/json"
+}
+
+response = requests.post(url, data=json.dumps(payload), headers=headers)
+
+if response.status_code == 200:
+    print("Success:")
+    print(response.json())
+else:
+    print(f"Error: {response.status_code}")
+    print(response.text)
+```
+*This example uses the `prompt` field for a single-turn interaction.*
+
+---
+
+**Examples for Conversational Interaction (using `messages`):**
+
+**`curl`:**
+```bash
+curl -X POST "http://127.0.0.1:8000/generate" -H "Content-Type: application/json" -d '{
+  "model": "llama3",
+  "messages": [
+    {"role": "user", "content": "Hello! Can you tell me about the history of large language models?"},
+    {"role": "assistant", "content": "Certainly! The history of large language models dates back to the mid-20th century... (summary of response A)"},
+    {"role": "user", "content": "That''s interesting. What were some of the key breakthroughs?"}
+  ]
+}'
+```
+
+**Python `requests`:**
+```python
+import requests
+import json
+
+url = "http://127.0.0.1:8000/generate"
+payload = {
+    "model": "llama3",
+    "messages": [
+        {"role": "user", "content": "What is the capital of France?"},
+        {"role": "assistant", "content": "The capital of France is Paris."},
+        {"role": "user", "content": "What is a famous landmark there?"}
+    ]
 }
 headers = {
     "Content-Type": "application/json"

--- a/main.py
+++ b/main.py
@@ -8,24 +8,33 @@ app = FastAPI()
 # Define a Pydantic model for the request body
 class GenerateRequest(BaseModel):
     model: str
-    prompt: str
+    prompt: str | None = None
+    messages: list[dict] | None = None
 
 # Create a POST endpoint /generate
 @app.post("/generate")
 async def generate(request: GenerateRequest):
+    if not request.prompt and (not request.messages or len(request.messages) == 0):
+        raise HTTPException(
+            status_code=422,
+            detail="Either 'prompt' or a non-empty 'messages' list must be provided."
+        )
+
     try:
         # Initialize an ollama.Client instance
         client = Client()
 
+        message_list_to_send = []
+        if request.messages and len(request.messages) > 0:
+            message_list_to_send = request.messages
+        elif request.prompt:
+            message_list_to_send = [{'role': 'user', 'content': request.prompt}]
+        # The case where both are empty/None is caught by the check above
+
         # Call client.chat()
         response = client.chat(
             model=request.model,
-            messages=[
-                {
-                    'role': 'user',
-                    'content': request.prompt,
-                }
-            ]
+            messages=message_list_to_send
         )
         # Return the response dictionary directly
         return response

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,10 +51,116 @@ def test_generate_ollama_error(MockOllamaClient):
     )
 
 def test_generate_invalid_request_body():
-    # Missing 'prompt'
-    response = client.post("/generate", json={"model": "llama3"})
-    assert response.status_code == 422 # Unprocessable Entity for Pydantic validation errors
-
-    # Missing 'model'
-    response = client.post("/generate", json={"prompt": "test"})
+    # Missing 'model' - Pydantic validation
+    response = client.post("/generate", json={"prompt": "test"}) # 'model' is required by Pydantic
     assert response.status_code == 422
+    # Ensure the error is about 'model' being missing if possible, or just check 422
+    # For example, Pydantic v2 might return:
+    # {'detail': [{'type': 'missing', 'loc': ['body', 'model'], 'msg': 'Field required', 'input': {'prompt': 'test'}}]}
+    # For simplicity, just checking status 422 is often sufficient for this test's scope.
+
+    # Test with 'model' but no prompt or messages (covered by specific tests below, but good for Pydantic check)
+    response = client.post("/generate", json={"model": "llama3"})
+    assert response.status_code == 422 
+    assert response.json() == {"detail": "Either 'prompt' or a non-empty 'messages' list must be provided."}
+
+
+@patch('ollama.Client')
+def test_generate_with_conversation_history(MockOllamaClient):
+    mock_ollama_instance = MockOllamaClient.return_value
+    messages_payload = [
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "How are you?"}
+    ]
+    mock_response_content = "I'm doing well, thank you for asking!"
+    mock_ollama_response = {
+        "model": "llama3",
+        "created_at": "2023-10-27T10:00:00Z",
+        "message": {"role": "assistant", "content": mock_response_content},
+        "done": True
+    }
+    mock_ollama_instance.chat.return_value = mock_ollama_response
+
+    response = client.post("/generate", json={"model": "llama3", "messages": messages_payload})
+
+    assert response.status_code == 200
+    assert response.json() == mock_ollama_response
+    mock_ollama_instance.chat.assert_called_once_with(
+        model="llama3",
+        messages=messages_payload
+    )
+
+@patch('ollama.Client')
+def test_generate_messages_takes_precedence_over_prompt(MockOllamaClient):
+    mock_ollama_instance = MockOllamaClient.return_value
+    messages_payload = [{"role": "user", "content": "From messages"}]
+    mock_response_content = "Response based on messages"
+    mock_ollama_response = {
+        "model": "llama3",
+        "message": {"role": "assistant", "content": mock_response_content},
+        "done": True
+    }
+    mock_ollama_instance.chat.return_value = mock_ollama_response
+
+    response = client.post(
+        "/generate",
+        json={"model": "llama3", "prompt": "This should be ignored", "messages": messages_payload}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"]["content"] == mock_response_content
+    mock_ollama_instance.chat.assert_called_once_with(
+        model="llama3",
+        messages=messages_payload
+    )
+
+@patch('ollama.Client')
+def test_generate_empty_messages_list_with_prompt(MockOllamaClient):
+    mock_ollama_instance = MockOllamaClient.return_value
+    prompt_payload = "Use this prompt"
+    expected_messages_to_ollama = [{"role": "user", "content": prompt_payload}]
+    mock_response_content = "Response based on prompt"
+    mock_ollama_response = {
+        "model": "llama3",
+        "message": {"role": "assistant", "content": mock_response_content},
+        "done": True
+    }
+    mock_ollama_instance.chat.return_value = mock_ollama_response
+
+    response = client.post(
+        "/generate",
+        json={"model": "llama3", "prompt": prompt_payload, "messages": []} # Empty messages list
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"]["content"] == mock_response_content
+    mock_ollama_instance.chat.assert_called_once_with(
+        model="llama3",
+        messages=expected_messages_to_ollama
+    )
+
+def test_generate_missing_prompt_and_messages():
+    response = client.post("/generate", json={"model": "llama3"}) # Neither prompt nor messages
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Either 'prompt' or a non-empty 'messages' list must be provided."}
+
+def test_generate_empty_messages_list_and_no_prompt():
+    response = client.post("/generate", json={"model": "llama3", "messages": []}) # Empty messages, no prompt
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Either 'prompt' or a non-empty 'messages' list must be provided."}
+
+@patch('ollama.Client')
+def test_generate_ollama_error_with_messages(MockOllamaClient):
+    mock_ollama_instance = MockOllamaClient.return_value
+    mock_ollama_instance.chat.side_effect = Exception("Ollama connection error with messages")
+    messages_payload = [{"role": "user", "content": "Test with messages"}]
+
+    response = client.post("/generate", json={"model": "llama3", "messages": messages_payload})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Error interacting with Ollama API: Ollama connection error with messages"}
+    mock_ollama_instance.chat.assert_called_once_with(
+        model="llama3",
+        messages=messages_payload
+    )


### PR DESCRIPTION
This commit enhances the Ollama FastAPI wrapper by adding support for conversational interactions.

Key changes:
- The `/generate` endpoint now accepts an optional `messages` field in the request body. This field is a list of message objects (each with `role` and `content`) to provide conversational history.
- If `messages` are provided, they are used for the Ollama `chat` call. Otherwise, the existing `prompt` field is used for single-turn interactions.
- Validation added to ensure that either `prompt` or a non-empty `messages` list is provided.
- `README.md` updated with detailed instructions and examples for using the new conversation mode with both `curl` and Python `requests`.
- Comprehensive unit tests added for the conversation mode, covering:
    - Successful generation with `messages`.
    - Precedence of `messages` over `prompt`.
    - Handling of empty or missing `prompt` and `messages`.
    - Error handling for Ollama API calls when using `messages`.
- Existing tests were updated to align with the new validation logic.